### PR TITLE
Master: add local mock in container policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ allow this access for now by executing:
 
 ```
 
-While we work on a fix for this issue, please set SELinux to permissive mode by executing `setenforce 0` before running the script. Don't forget changing it back after you're done: `setenforce 1`
+One way to make this work is to set SELinux to permissive mode by executing `setenforce 0` (don't forget changing it back after you're done: `setenforce 1`).
+
+Another it to use a local policy package that permits the required access. Use these commands to build and install it:
+
+```
+checkmodule -M -m -o files/my-mock-in-container.mod files/my-mock-in-container-fedora-25.te
+semodule_package -o files/my-mock-in-container.pp -m files/my-mock-in-container.mod
+sudo semodule -i files/my-mock-in-container.pp
+```
+
+The type enforcement file used as a source was generated on Fedora 25, your mileage may vary on other distribution versions.
 
 ## Requirements
 

--- a/build_module
+++ b/build_module
@@ -36,5 +36,5 @@ if [ $? -eq 0 -a "$getenforce_out" != "Disabled" ]; then
     label_flag=:z
 fi
 
-docker run --cap-add=SYS_ADMIN --rm -it -v "${module_repo}:/source/${module_name}${label_flag}" -v "${results_dir}:/results${label_flag}" asamalik/build-module /usr/bin/mbs-manager build_module_locally "file:////source/${module_name}?#master"
+docker run --cap-add=SYS_ADMIN --rm -it -v "${module_repo}:/source/${module_name}${label_flag}" -v "${results_dir}:/results${label_flag}" asamalik/build-module /usr/bin/mbs-manager build_module_locally "file:///source/${module_name}?#master"
 

--- a/files/my-mock-in-container-fedora-25.te
+++ b/files/my-mock-in-container-fedora-25.te
@@ -1,0 +1,29 @@
+
+module my-mock-in-container 1.0;
+
+require {
+	type user_home_t;
+	type container_t;
+	type tmpfs_t;
+	type container_file_t;
+	type devpts_t;
+	type container_t;
+	type proc_t;
+	type sysfs_t;
+	class dir write;
+	class blk_file { create unlink };
+	class filesystem mount;
+	class file { append create ioctl open read setattr write };
+	class dir { add_name write };
+}
+
+#============= container_t ==============
+allow container_t container_file_t:blk_file { create unlink };
+allow container_t devpts_t:dir write;
+allow container_t devpts_t:filesystem mount;
+allow container_t proc_t:filesystem mount;
+allow container_t sysfs_t:filesystem mount;
+allow container_t tmpfs_t:dir write;
+allow container_t tmpfs_t:filesystem mount;
+allow container_t user_home_t:dir { add_name write };
+allow container_t user_home_t:file { append create ioctl open read setattr write };


### PR DESCRIPTION
Additionally, remove the stray slash from the local module source URL (the third slash is already part of the local path).